### PR TITLE
Fix loop parsing logic

### DIFF
--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -117,8 +117,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_loop(&mut self) -> Cmd {
-        match self.next_token_past_newline() {
-            Some("\n") => panic!("Could not find count identifier for loop"),
+        match self.first_non_whitespace_token() {
             None => panic!("Unexpected end of input: Loop stub not provided with loop count"),
             Some(other) => Cmd::Loop {
                 count_var: String::from(other),
@@ -128,8 +127,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_loopable(&mut self) -> Cmd {
-        match self.next_token_past_newline() {
-            Some("\n") => panic!("Loop not provided with command"),
+        match self.first_non_whitespace_token() {
             Some("read") => self.parse_read(),
             Some("write") => self.parse_write(),
             Some("loopline") => self.parse_loopline(),
@@ -140,8 +138,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_loopline(&mut self) -> Cmd {
-        match self.next_token_past_newline() {
-            Some("\n") => panic!("Could not find count identifier for loopline"),
+        match self.first_non_whitespace_token() {
             None => panic!("Unexpected end of input: Loopline stub not provided with count identifier"),
             Some(other) => Cmd::LoopLine {
                 count_var: other.to_string(),
@@ -254,12 +251,13 @@ impl<'a> Parser<'a> {
         self.token_stream.next()
     }
 
-    fn next_token_past_newline(&mut self) -> Option<&'a str> {
-        match self.next_token() {
-            Some("\n") => self.next_token(),
-            Some("") => self.next_token_past_newline(),
-            token => token,
+    fn first_non_whitespace_token(&mut self) -> Option<&'a str> {
+        while let Some(token) = self.token_stream.next() {
+            if token != "\n" && token != "" {
+                return Some(token);
+            }
         }
+        None
     }
 
     fn rest_of_line(&mut self) -> Option<String> {

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -441,6 +441,32 @@ for i in range(x_count):
 }
 
 #[test]
+fn test_loops_spaces_and_newlines() {
+    let generator = r##"read n:int
+loop  
+  n    
+    
+
+  loop 4 
+write thing
+
+loop n    
+  loop 4      
+  loopline
+n x:int"##;
+    let expected = r##"n = int(input())
+for i in range(n):
+    for j in range(4):
+        print("thing")
+for i in range(n):
+    for j in range(4):
+        for k in input().split():
+            x = int(k)
+"##;
+    test_stub_builder(generator, expected);
+}
+
+#[test]
 fn test_stub_variable_length() {
     let generator = r##"read n:int
 read k:string(n)


### PR DESCRIPTION
Fixes a parser crash when whitespace was placed aroun loop terms, cf. [this clash.](https://www.codingame.com/contribute/view/286928b731dd04d9229ae73173ce99ecdc121)

I also added a pathological test for this.