### PR TITLE
Generate stub bugfixing

### DIFF
--- a/config/stub_templates/python/read_many.py.jinja
+++ b/config/stub_templates/python/read_many.py.jinja
@@ -29,7 +29,9 @@
 inputs = input().split()
 {%- for var in vars %}
 {% if var.var_type == "String" or var.var_type == "Word" -%}
-    {%- set assign = "inputs[" ~ loop.index0  ~ "]" -%}
+    {%- set assign = "inputs[" ~ loop.index0 ~ "]" -%}
+{%- elif var.var_type == "Bool" -%}
+    {%- set assign = "inputs[" ~ loop.index0 ~ "]" ~ type_tokens[var.var_type] -%}
 {% else -%}
     {%- set assign = type_tokens[var.var_type] ~ "(inputs[" ~ loop.index0 ~ "])" -%}
 {% endif -%}

--- a/config/stub_templates/python/write_join.py.jinja
+++ b/config/stub_templates/python/write_join.py.jinja
@@ -9,12 +9,11 @@
   {%- else -%}
     {%- set_global out = out ~ '"' ~ term.name ~ '"' -%}
   {%- endif -%}
-  {%- if loop.last == false %}
+  {%- if loop.last == false -%}
     {%- set_global out = out ~ ' + " " + ' -%}
-  {% endif %}
+  {%- endif -%}
 {%- endfor -%}
 
-{%- for line in output_comments %}
-# {{ line }}
-{%- endfor -%}
+{%- for line in output_comments -%} # {{ line }}
+{% endfor -%}
 print({{ out | replace(from='" + "', to="") }})

--- a/src/stub/language/variable_name_options.rs
+++ b/src/stub/language/variable_name_options.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::stub::VariableCommand;
 
 lazy_static! {
-    static ref SC_WORD_BREAK: Regex = Regex::new(r"([a-z])([A-Z])").unwrap();
+    static ref SC_WORD_BREAK: Regex = Regex::new(r"([a-z])([A-Z0-9])").unwrap();
     static ref PC_WORD_BREAK: Regex = Regex::new(r"([A-Z]*)([A-Z][a-z])").unwrap();
     static ref PC_WORD_END: Regex = Regex::new(r"([A-Z])([A-Z]*$)").unwrap();
 }

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -441,7 +441,7 @@ for i in range(x_count):
 }
 
 #[test]
-fn test_loops_spaces_and_newlines() {
+fn test_stub_loops_spaces_and_newlines() {
     let generator = r##"read n:int
 loop  
   n    
@@ -481,6 +481,69 @@ k = input()  # this string is n-sized (irrelevant in python but be wary!)
 for i in range(n):
     a = input()
 print("answer")
+"##;
+
+    test_stub_builder(generator, expected);
+}
+
+#[test]
+fn test_stub_summary() {
+    let generator = r##"read anInt:int
+read aFloat:float
+read Long:long
+read aWord:word(1)
+read boolean:bool
+read ABC1ABc1aBC1AbC1abc1:int
+read STRING:string(256)
+read anInt2:int aFloat2:float Long2:long aWord2:word(1) boolean2:bool
+loop anInt read x:int
+loop anInt read x:int f:float
+loopline anInt x:int
+loopline anInt x:int f:float
+write result
+
+write join(anInt, aFloat, "literal", boolean)
+
+STATEMENT
+This is the statement
+
+INPUT
+anInt: An input comment over anInt
+
+OUTPUT
+An output comment
+"##;
+    let expected = r##"# This is the statement
+
+an_int = int(input())  # An input comment over anInt
+a_float = float(input())
+long = int(input())
+a_word = input()
+boolean = input() != "0"
+abc1abc_1a_bc1ab_c1abc_1 = int(input())
+string = input()
+inputs = input().split()
+an_int_2 = int(inputs[0])
+a_float_2 = float(inputs[1])
+long_2 = int(inputs[2])
+a_word_2 = inputs[3]
+boolean_2 = inputs[4] != "0"
+for i in range(an_int):
+    x = int(input())
+for i in range(an_int):
+    inputs = input().split()
+    x = int(inputs[0])
+    f = float(inputs[1])
+for i in input().split():
+    x = int(i)
+inputs = input().split()
+for i in range(an_int):
+    x = int(inputs[2*i])
+    f = float(inputs[2*i+1])
+# An output comment
+print("result")
+# An output comment
+print(str(an_int) + " " + str(a_float) + " literal " + str(boolean))
 "##;
 
     test_stub_builder(generator, expected);


### PR DESCRIPTION
I only fixed snake case for identifiers with numbers, I haven't tested other casing because atm all the supported languages use that casing. It shouldn't be hard to fix it in the future if we ever have a template for Java / C# or the likings.

I purposely didn't include strings or words in this writejoin: `write join(anInt, aFloat, "literal", boolean)`

Tell me if you think the added test covers all the relevant (basic) parts of a template.