### PR TITLE
Add types to JoinTerms

### DIFF
--- a/config/stub_templates/c/loop.c.jinja
+++ b/config/stub_templates/c/loop.c.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOP
-{% endif -%}
-
 for (int {{ index_ident }} = 0; {{ index_ident }} < {{ count_var }}; {{ index_ident }}++) {
 {%- for line in inner %}
     {{line}}

--- a/config/stub_templates/c/loopline.c.jinja
+++ b/config/stub_templates/c/loopline.c.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOPLINE
-{% endif -%}
-
 for (int i = 0; i < {{ count_var }}; i++) {
 {%- for var in vars %}
     {%- set sym = format_symbols[var.var_type] -%}

--- a/config/stub_templates/c/read_many.c.jinja
+++ b/config/stub_templates/c/read_many.c.jinja
@@ -1,12 +1,3 @@
-{%- if debug_mode -%}
----- 🇷 EAD_MANY
-{%- if single_type -%} 
-  (SINGLE_TYPE)
-{% else -%}
-  (MULTIPLE_TYPE)
-{% endif -%}
-{% endif -%}
-
 {%- for var in vars %}
 {%- if var.input_comment -%}# {{ var.ident }}: {{ var.input_comment }}
 {% endif -%}

--- a/config/stub_templates/c/read_one.c.jinja
+++ b/config/stub_templates/c/read_one.c.jinja
@@ -1,11 +1,3 @@
-{% if debug_mode -%}
----- 🇷 EAD_ONE: {{ var.var_type }}
-{% endif %}
-
-{%- if comment -%}
-// {{ comment.description }}
-{% endif %}
-
 {%- set sym = format_symbols[var.var_type] -%}
 {%- set type_kw = type_tokens[var.var_type] -%}
 {%- if var.var_type == "String" or var.var_type == "Word" -%}
@@ -16,5 +8,7 @@
   {%- set ref = "&" -%}
 {%- endif -%}
 
-{{ type_kw }} {{ var.ident }}{{ len }};
+{%- if var.input_comment %}// {{ var.input_comment }}
+{% endif -%}
+{{ type_kw }} {{ var.ident }}{{ len }}; 
 scanf("{{ sym }}", {{ ref }}{{ var.ident }});

--- a/config/stub_templates/c/stub_config.toml
+++ b/config/stub_templates/c/stub_config.toml
@@ -12,7 +12,13 @@ Word = "char"
 [variable_name_options]
 casing = "snake_case"
 allow_uppercase_vars = false
-# TODO
 keywords = [
-  "for" 
+  "auto", "break", "case", "char",
+  "const", "continue", "default", "do",
+  "double", "else", "enum", "extern",
+  "float", "for", "goto", "if",
+  "int", "long", "register", "return",
+  "short", "signed", "sizeof", "static",
+  "struct", "switch", "typedef", "union",
+  "unsigned", "void", "volatile", "while"
 ]

--- a/config/stub_templates/c/write.c.jinja
+++ b/config/stub_templates/c/write.c.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE
-{% endif -%}
-
 {%- for line in output_comments %}
 // {{ line }}
 {% endfor %}

--- a/config/stub_templates/c/write_join.c.jinja
+++ b/config/stub_templates/c/write_join.c.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE_JOIN
-{% endif -%}
-
 {%- set_global types = [] -%}
 {%- set_global term_refs = [] -%}
 {%- for term in terms -%}

--- a/config/stub_templates/c/write_join.c.jinja
+++ b/config/stub_templates/c/write_join.c.jinja
@@ -11,10 +11,25 @@
   {%- if term.is_variable %}
     {%- set ref = "TODO" -%}
   {%- else -%}
-    {%- set ref = term.name -%}
+    {%- set ref = term.ident -%}
   {%- endif -%}
   {%- set_global joined_terms = joined_terms | concat(with=ref) -%}
 {%- endfor -%}
 {%- set fmt_joined_terms = joined_terms | join(sep=" ") -%}
 
-printf("{{ fmt_joined_terms }}");
+{%- set_global types = [] -%}
+{%- set_global var_refs = [] -%}
+{%- for var in terms -%}
+  {# var_type is None when the term is a literal #}
+  {%- if var.var_type -%}
+    {%- set_global var_refs = var_refs | concat(with=var.ident) -%}
+  {%- endif -%}
+
+  {%- if var.var_type -%}
+    {%- set_global types = types | concat(with=format_symbols[var.var_type]) -%}
+  {%- else -%}
+    {%- set_global types = types | concat(with=var.ident) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+printf("{{ types | join(sep=" ") }}\n", {{ var_refs | join(sep=", ") }});

--- a/config/stub_templates/c/write_join.c.jinja
+++ b/config/stub_templates/c/write_join.c.jinja
@@ -1,35 +1,17 @@
-{#
-    This only deals with WriteJoin with literals at the moment.
-#}
-
 {%- if debug_mode -%}
 ---- 🇼 RITE_JOIN
 {% endif -%}
 
-{%- set_global joined_terms = [] -%}
-{%- for term in terms -%}
-  {%- if term.is_variable %}
-    {%- set ref = "TODO" -%}
-  {%- else -%}
-    {%- set ref = term.ident -%}
-  {%- endif -%}
-  {%- set_global joined_terms = joined_terms | concat(with=ref) -%}
-{%- endfor -%}
-{%- set fmt_joined_terms = joined_terms | join(sep=" ") -%}
-
 {%- set_global types = [] -%}
-{%- set_global var_refs = [] -%}
-{%- for var in terms -%}
+{%- set_global term_refs = [] -%}
+{%- for term in terms -%}
   {# var_type is None when the term is a literal #}
-  {%- if var.var_type -%}
-    {%- set_global var_refs = var_refs | concat(with=var.ident) -%}
-  {%- endif -%}
-
-  {%- if var.var_type -%}
-    {%- set_global types = types | concat(with=format_symbols[var.var_type]) -%}
+  {%- if term.var_type -%}
+    {%- set_global term_refs = term_refs | concat(with=term.ident) -%}
+    {%- set_global types = types | concat(with=format_symbols[term.var_type]) -%}
   {%- else -%}
-    {%- set_global types = types | concat(with=var.ident) -%}
+    {%- set_global types = types | concat(with=term.ident) -%}
   {%- endif -%}
 {%- endfor -%}
 
-printf("{{ types | join(sep=" ") }}\n", {{ var_refs | join(sep=", ") }});
+printf("{{ types | join(sep=" ") }}\n", {{ term_refs | join(sep=", ") }});

--- a/config/stub_templates/cpp/loop.cpp.jinja
+++ b/config/stub_templates/cpp/loop.cpp.jinja
@@ -1,0 +1,5 @@
+for (int {{ index_ident }} = 0; {{ index_ident }} < {{ count_var }}; {{ index_ident }}++) {
+{%- for line in inner %}
+    {{line}}
+{%- endfor %}
+}

--- a/config/stub_templates/cpp/loopline.cpp.jinja
+++ b/config/stub_templates/cpp/loopline.cpp.jinja
@@ -1,0 +1,6 @@
+for (int i = 0; i < {{ count_var }}; i++) {
+{%- for var in vars %}
+    {{ type_tokens[var.var_type] }} {{ var.ident }};
+    cin >> {{ var.ident }}; cin.ignore();
+{%- endfor %}
+}

--- a/config/stub_templates/cpp/main.cpp.jinja
+++ b/config/stub_templates/cpp/main.cpp.jinja
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+{% for line in statement %}
+// {{ line }}
+{%- endfor %}
+
+int main() {
+    {%- for line in code_lines %}
+    {{ line }}
+    {%- endfor %}
+
+    return 0;
+}

--- a/config/stub_templates/cpp/read_many.cpp.jinja
+++ b/config/stub_templates/cpp/read_many.cpp.jinja
@@ -1,0 +1,27 @@
+{%- for var in vars %}
+{%- if var.input_comment -%}# {{ var.ident }}: {{ var.input_comment }}
+{% endif -%}
+{% endfor -%}
+
+{# Setup of types (%d, %s etc.) and variable references (& or "") inside the scanf function #}
+{%- set_global types = "" -%}
+{%- set_global cin_msg = "cin" -%}
+{%- for var in vars -%}  
+  {%- set_global cin_msg = cin_msg ~ " >> " ~ var.ident -%}
+  {%- set_global types = types ~ format_symbols[var.var_type] -%}
+{%- endfor -%}
+
+{%- if single_type -%}
+
+{%- set_global type = vars[0].var_type -%}
+{{ type_tokens[type] }} {{ vars | map(attribute="ident") | join(sep=", ") }};
+{{ cin_msg }}; cin.ignore();
+
+{%- else %}
+
+{%- for var in vars -%}
+{{ type_tokens[var.var_type] }} {{ var.ident }};
+{% endfor -%}
+{{ cin_msg }}; cin.ignore();
+
+{%- endif %}

--- a/config/stub_templates/cpp/read_one.cpp.jinja
+++ b/config/stub_templates/cpp/read_one.cpp.jinja
@@ -1,0 +1,6 @@
+{%- set type_kw = type_tokens[var.var_type] -%}
+
+{%- if var.input_comment %}// {{ var.input_comment }}
+{% endif -%}
+{{ type_kw }} {{ var.ident }}; 
+cin >> {{ var.ident }}; cin.ignore();

--- a/config/stub_templates/cpp/stub_config.toml
+++ b/config/stub_templates/cpp/stub_config.toml
@@ -1,0 +1,24 @@
+name = "cpp"
+source_file_ext = "cpp"
+
+[type_tokens]
+Int = "int"
+Long = "long long"
+Float = "float"
+Bool = "int"
+String = "string"
+Word = "string"
+
+[variable_name_options]
+casing = "snake_case"
+allow_uppercase_vars = false
+keywords = [
+  "auto", "break", "case", "char",
+  "const", "continue", "default", "do",
+  "double", "else", "enum", "extern",
+  "float", "for", "goto", "if",
+  "int", "long", "register", "return",
+  "short", "signed", "sizeof", "static",
+  "struct", "switch", "typedef", "union",
+  "unsigned", "void", "volatile", "while"
+]

--- a/config/stub_templates/cpp/write.cpp.jinja
+++ b/config/stub_templates/cpp/write.cpp.jinja
@@ -1,0 +1,6 @@
+{%- for line in output_comments %}
+// {{ line }}
+{% endfor %}
+{%- for line in messages -%}
+cout << "{{line}}" << endl;
+{% endfor %}

--- a/config/stub_templates/cpp/write_join.cpp.jinja
+++ b/config/stub_templates/cpp/write_join.cpp.jinja
@@ -1,0 +1,15 @@
+{%- set_global out = "" -%}
+{%- for term in terms -%}
+  {%- if term.is_variable -%}
+    {%- set_global out = out ~ term.ident -%}
+  {%- else -%}
+    {%- set_global out = out ~ '"' ~ term.ident ~ '"' -%}
+  {%- endif -%}
+  {%- if loop.last == false -%}
+    {%- set_global out = out ~ ' << " " << ' -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- for line in output_comments -%} # {{ line }}
+{% endfor -%}
+cout << {{ out | replace(from='" << "', to="") }} << endl;

--- a/config/stub_templates/python/loop.py.jinja
+++ b/config/stub_templates/python/loop.py.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOP
-{% endif -%}
-
 for {{ index_ident }} in range({{ count_var }}):
 {%- for line in inner %}
     {{line}}

--- a/config/stub_templates/python/loopline.py.jinja
+++ b/config/stub_templates/python/loopline.py.jinja
@@ -1,12 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOPLINE
-{%- if vars | length == 1 -%} 
-  (SINGLE_TYPE)
-{% else -%}
-  (MULTIPLE_TYPE)
-{% endif -%}
-{% endif -%}
-
 {%- if vars | length == 1 -%} 
 {# SINGLE_TYPE #}
 {%- set var = vars[0] -%}

--- a/config/stub_templates/python/main.py.jinja
+++ b/config/stub_templates/python/main.py.jinja
@@ -1,10 +1,3 @@
-{% if debug_mode %}
----- 🇲 AIN
-{% endif -%}
-{% if debug_mode -%}
----- 🇸 TATEMENT
-{% endif -%}
-
 {%- for line in statement -%}
 # {{ line }}
 {% endfor %}

--- a/config/stub_templates/python/read_many.py.jinja
+++ b/config/stub_templates/python/read_many.py.jinja
@@ -20,7 +20,7 @@
 {%- if type == "String" or type == "Word" -%}
     {%- set assign = "input().split()" -%}
 {%- else -%}
-    {%- set assign = "[" ~ type_tokens[type] ~ "(i) for i in input().split()]" -%}
+    {%- set assign = "[" ~ type_tokens[type] ~ "(" ~ index_ident ~ ") for " ~ index_ident ~ " in input().split()]" -%}
 {%- endif -%}
 {{ names }} = {{ assign }}
 

--- a/config/stub_templates/python/read_many.py.jinja
+++ b/config/stub_templates/python/read_many.py.jinja
@@ -1,12 +1,3 @@
-{%- if debug_mode -%}
----- 🇷 EAD_MANY
-{%- if single_type -%} 
-  (SINGLE_TYPE)
-{% else -%}
-  (MULTIPLE_TYPE)
-{% endif -%}
-{% endif -%}
-
 {%- set_global names = vars | map(attribute="ident") | join(sep=", ") -%}
 
 {%- if single_type -%}

--- a/config/stub_templates/python/read_one.py.jinja
+++ b/config/stub_templates/python/read_one.py.jinja
@@ -1,7 +1,3 @@
-{% if debug_mode -%}
----- 🇷 EAD_ONE: {{ var.var_type }}
-{% endif %}
-
 {%- if var.var_type == "String" or var.var_type == "Word" -%}
     {%- set fn = "input()" -%}
 {%- elif var.var_type == "Bool" -%}

--- a/config/stub_templates/python/write.py.jinja
+++ b/config/stub_templates/python/write.py.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE
-{% endif -%}
-
 {%- for line in output_comments -%}
 # {{ line }}
 {% endfor %}

--- a/config/stub_templates/python/write_join.py.jinja
+++ b/config/stub_templates/python/write_join.py.jinja
@@ -5,9 +5,13 @@
 {%- set_global out = "" -%}
 {%- for term in terms -%}
   {%- if term.is_variable -%}
-    {%- set_global out = out ~ "str(" ~ term.name ~ ")" -%}
+    {%- if term.var_type == "String" or term.var_type == "Word" -%}
+      {%- set_global out = out ~ term.ident -%}
+    {%- else -%}
+      {%- set_global out = out ~ "str(" ~ term.ident ~ ")" -%}
+    {%- endif -%}
   {%- else -%}
-    {%- set_global out = out ~ '"' ~ term.name ~ '"' -%}
+    {%- set_global out = out ~ '"' ~ term.ident ~ '"' -%}
   {%- endif -%}
   {%- if loop.last == false -%}
     {%- set_global out = out ~ ' + " " + ' -%}

--- a/config/stub_templates/python/write_join.py.jinja
+++ b/config/stub_templates/python/write_join.py.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE_JOIN
-{% endif -%}
-
 {%- set_global out = "" -%}
 {%- for term in terms -%}
   {%- if term.is_variable -%}

--- a/config/stub_templates/ruby/loop.rb.jinja
+++ b/config/stub_templates/ruby/loop.rb.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOP
-{% endif -%}
-
 {{ count_var }}.times do
 {%- for line in inner %}
   {{line}}

--- a/config/stub_templates/ruby/loopline.rb.jinja
+++ b/config/stub_templates/ruby/loopline.rb.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇱 OOPLINE
-{% endif -%}
-
 {%- for var in vars %}
 {%- if var.input_comment -%}# {{ var.ident }}: {{ var.input_comment }}
 {% endif -%}

--- a/config/stub_templates/ruby/main.rb.jinja
+++ b/config/stub_templates/ruby/main.rb.jinja
@@ -1,10 +1,3 @@
-{% if debug_mode %}
----- 🇲 AIN
-{% endif -%}
-{% if debug_mode -%}
----- 🇸 TATEMENT
-{% endif -%}
-
 {%- for line in statement %}
 # {{ line }}
 {%- endfor %}

--- a/config/stub_templates/ruby/read_many.rb.jinja
+++ b/config/stub_templates/ruby/read_many.rb.jinja
@@ -1,12 +1,3 @@
-{%- if debug_mode -%}
----- 🇷 EAD_MANY
-{%- if single_type -%} 
-  (SINGLE_TYPE)
-{% else -%}
-  (MULTIPLE_TYPE)
-{% endif -%}
-{% endif -%}
-
 {%- for var in vars %}
 {%- if var.input_comment -%}# {{ var.ident }}: {{ var.input_comment }}
 {% endif -%}

--- a/config/stub_templates/ruby/read_one.rb.jinja
+++ b/config/stub_templates/ruby/read_one.rb.jinja
@@ -1,7 +1,3 @@
-{% if debug_mode -%}
----- 🇷 EAD_ONE: {{ var.var_type }}
-{% endif %}
-
 {%- if var.var_type == "String" -%}
   {% set method = ".chomp" %}
 {%- elif var.var_type == "Word" -%}

--- a/config/stub_templates/ruby/write.rb.jinja
+++ b/config/stub_templates/ruby/write.rb.jinja
@@ -2,11 +2,6 @@
     NOTE: CG prints the comments to the right if they are only one line long, 
     and above if multiline. We only do above, regardless of size, for the moment. 
 #}
-
-{%- if debug_mode -%}
----- 🇼 RITE
-{% endif -%}
-
 {%- for line in output_comments %}
 # {{ line }}
 {% endfor %}

--- a/config/stub_templates/ruby/write_join.rb.jinja
+++ b/config/stub_templates/ruby/write_join.rb.jinja
@@ -5,9 +5,9 @@
 puts "
 {%- for term in terms -%}
   {%- if term.is_variable -%}
-    {{- '#{' }}{{ term.name }}{{ '}' -}}
+    {{- '#{' }}{{ term.ident }}{{ '}' -}}
   {%- else -%}
-    {{- term.name -}}
+    {{- term.ident -}}
   {%- endif -%}
   {% if loop.last == false %} {% endif %}
 {%- endfor -%}"

--- a/config/stub_templates/ruby/write_join.rb.jinja
+++ b/config/stub_templates/ruby/write_join.rb.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE_JOIN
-{% endif -%}
-
 puts "
 {%- for term in terms -%}
   {%- if term.is_variable -%}

--- a/config/stub_templates/rust/loop.rs.jinja
+++ b/config/stub_templates/rust/loop.rs.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
-# LOOP
-{% endif -%}
-
 for {{ index_ident }} in 0..{{ count_var }} as usize {
 {%- for line in inner %}
     {{line}}

--- a/config/stub_templates/rust/loopline.rs.jinja
+++ b/config/stub_templates/rust/loopline.rs.jinja
@@ -1,7 +1,26 @@
-gets.split.each{% if vars | length > 1 %}_slice({{ vars | length }}){% endif %} do |{{ vars | map(attribute="ident") | join(sep=", ") }}|
-{%- for var in vars -%}
-{%- if var.var_type != "Word" %}
-  {{var.ident}} = {{var.ident}}.{{type_tokens[var.var_type]-}}
-{% endif -%}
+{%- if vars | length == 1 -%} 
+
+{%- set var = vars[0] -%}
+let mut inputs = String::new();
+io::stdin().read_line(&mut inputs).unwrap();
+for {{ index_ident }} in inputs.split_whitespace() {
+    let {{ var.ident }} = parse_input!({{ index_ident }}, {{type_tokens[var.var_type]}});
+}
+
+{%- else -%}
+
+let mut input_line = String::new();
+io::stdin().read_line(&mut input_line).unwrap();
+let inputs = input_line.split_whitespace().collect::<Vec<_>>();
+for {{ index_ident }} in 0..{{ count_var }} as usize {
+{%- for var in vars %}
+    {%- if loop.index0 == 0 -%}
+        {%- set idx = "" -%}
+    {%- else -%}
+        {%- set idx = "+" ~ loop.index0 -%}
+    {%- endif -%}
+    {%- set fn = "inputs[2*" ~ index_ident ~ idx ~ "]" %}
+    let {{ var.ident }} = parse_input!({{ fn }}, {{type_tokens[var.var_type]}});
 {%- endfor %}
-end
+}
+{%- endif %}

--- a/config/stub_templates/rust/loopline.rs.jinja
+++ b/config/stub_templates/rust/loopline.rs.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
-# LOOPLINE
-{% endif -%}
-
 gets.split.each{% if vars | length > 1 %}_slice({{ vars | length }}){% endif %} do |{{ vars | map(attribute="ident") | join(sep=", ") }}|
 {%- for var in vars -%}
 {%- if var.var_type != "Word" %}

--- a/config/stub_templates/rust/main.rs.jinja
+++ b/config/stub_templates/rust/main.rs.jinja
@@ -3,12 +3,6 @@ use std::io;
 macro_rules! parse_input {
     ($x:expr, $t:ident) => ($x.trim().parse::<$t>().unwrap())
 }
-{% if debug_mode %}
----- 🇲 AIN
-{% endif -%}
-{% if debug_mode -%}
----- 🇸 TATEMENT
-{% endif -%}
 
 {%- for line in statement %}
 // {{ line }}

--- a/config/stub_templates/rust/read_many.rs.jinja
+++ b/config/stub_templates/rust/read_many.rs.jinja
@@ -1,12 +1,3 @@
-{%- if debug_mode -%}
----- 🇷 EAD_MANY
-{%- if single_type -%} 
-  (SINGLE_TYPE)
-{% else -%}
-  (MULTIPLE_TYPE)
-{% endif -%}
-{% endif -%}
-
 {%- for var in vars %}
 {%- if var.input_comment -%}// {{ var.ident }}: {{ var.input_comment }}
 {% endif -%}

--- a/config/stub_templates/rust/read_one.rs.jinja
+++ b/config/stub_templates/rust/read_one.rs.jinja
@@ -1,7 +1,3 @@
-{% if debug_mode -%}
----- 🇷 EAD_ONE: {{ var.var_type }}
-{% endif -%}
-
 let mut input_line = String::new();
 io::stdin().read_line(&mut input_line).unwrap();
 

--- a/config/stub_templates/rust/write.rs.jinja
+++ b/config/stub_templates/rust/write.rs.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
----- 🇼 RITE
-{% endif -%}
-
 {%- for line in output_comments %}
 // {{ line }}
 {% endfor %}

--- a/config/stub_templates/rust/write_join.rs.jinja
+++ b/config/stub_templates/rust/write_join.rs.jinja
@@ -5,9 +5,9 @@
 puts "
 {%- for term in terms -%}
   {%- if term.is_variable -%}
-    {{- '#{' }}{{ term.name }}{{ '}' -}}
+    {{- '#{' }}{{ term.ident }}{{ '}' -}}
   {%- else -%}
-    {{- term.name -}}
+    {{- term.ident -}}
   {%- endif -%}
   {% if loop.last == false %} {% endif %}
 {%- endfor -%}"

--- a/config/stub_templates/rust/write_join.rs.jinja
+++ b/config/stub_templates/rust/write_join.rs.jinja
@@ -1,9 +1,13 @@
-puts "
+{%- set_global types = [] -%}
+{%- set_global term_refs = [] -%}
 {%- for term in terms -%}
-  {%- if term.is_variable -%}
-    {{- '#{' }}{{ term.ident }}{{ '}' -}}
+  {# var_type is None when the term is a literal #}
+  {%- if term.var_type -%}
+    {%- set_global term_refs = term_refs | concat(with=term.ident) -%}
+    {%- set_global types = types | concat(with="{}") -%}
   {%- else -%}
-    {{- term.ident -}}
+    {%- set_global types = types | concat(with=term.ident) -%}
   {%- endif -%}
-  {% if loop.last == false %} {% endif %}
-{%- endfor -%}"
+{%- endfor -%}
+
+println!("{{ types | join(sep=" ") }}", {{ term_refs | join(sep=", ") }});

--- a/config/stub_templates/rust/write_join.rs.jinja
+++ b/config/stub_templates/rust/write_join.rs.jinja
@@ -1,7 +1,3 @@
-{%- if debug_mode -%}
-# WRITE_JOIN
-{% endif -%}
-
 puts "
 {%- for term in terms -%}
   {%- if term.is_variable -%}

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,7 @@ read STRING:string(256)
 read anInt2:int aFloat2:float Long2:long aWord2:word(1) boolean2:bool
 loop anInt read x:int
 loop anInt read x:int f:float
+loop anInt loop anInt read x:int y:int
 loopline anInt x:int
 loopline anInt x:int f:float
 write result

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,16 +502,18 @@ loopline anInt x:int
 loopline anInt x:int f:float
 write result
 
-write join(anInt, aFloat, "literal", boolean)
+OUTPUT
+An output comment
+
+write join(anInt, aFloat, Long, boolean)
+
+write join(aWord, "literal", STRING)
 
 STATEMENT
 This is the statement
 
 INPUT
 anInt: An input comment over anInt
-
-OUTPUT
-An output comment
 "##;
 
         let stub_generator = if args.get_flag("debug") {

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -278,4 +278,10 @@ puts "hello #{a} planet""##;
         let cfg = StubConfig::read_from_embedded("c").unwrap();
         generate(cfg, REFERENCE_STUB).unwrap();
     }
+
+    #[test]
+    fn test_reference_stub_cpp() {
+        let cfg = StubConfig::read_from_embedded("cpp").unwrap();
+        generate(cfg, REFERENCE_STUB).unwrap();
+    }
 }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -12,10 +12,9 @@ pub fn generate(config: StubConfig, generator: &str) -> Result<String> {
     let stub = parser::parse_generator_stub(generator);
 
     // eprint!("=======\n{:?}\n======\n", generator);
-    eprint!("=======\n{}\n======\n", renderer::render_stub(config.clone(), stub.clone(), true)?);
     // eprint!("=======\n{:?}\n======\n", stub);
 
-    let output_str = renderer::render_stub(config.clone(), stub, false)?;
+    let output_str = renderer::render_stub(config.clone(), stub)?;
 
     Ok(output_str.as_str().trim().to_string())
 }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -37,7 +37,7 @@ impl std::fmt::Debug for Stub {
     }
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Hash)]
 pub enum VarType {
     Int,
     Float,

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -88,22 +88,25 @@ impl VariableCommand {
 
 #[derive(Serialize, Clone, Debug)]
 pub struct JoinTerm {
-    pub name: String,
+    pub ident: String,
     pub is_variable: bool,
+    pub var_type: Option<VarType>,
 }
 
 impl JoinTerm {
-    pub fn new_literal(name: String) -> Self {
+    pub fn new_literal(ident: String) -> Self {
         Self {
-            name,
+            ident,
             is_variable: false,
+            var_type: None,
         }
     }
 
-    pub fn new_variable(name: String) -> Self {
+    pub fn new_variable(ident: String) -> Self {
         Self {
-            name,
+            ident,
             is_variable: true,
+            var_type: None,
         }
     }
 }

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -45,22 +45,20 @@ impl<'a> Parser<'a> {
             };
         }
 
-        let mut read_pairings = Vec::new();
+        // Update WriteJoin terms with their respective var_type.
+        let mut read_pairings = std::collections::BTreeMap::new();
         for read_cmd in &stub.commands {
             if let Cmd::Read(var_cmds) = read_cmd {
                 for var_cmd in var_cmds {
-                    read_pairings.push((var_cmd.ident.clone(), var_cmd.var_type.clone()));
+                    read_pairings.insert(var_cmd.ident.clone(), var_cmd.var_type);
                 }
             }
         }        
-
         for cmd in &mut stub.commands {
             if let Cmd::WriteJoin { join_terms, output_comment: _ } = cmd {
                 for term in join_terms.iter_mut() {
-                    for (ident, var_type) in &read_pairings {
-                        if term.ident == *ident {
-                            term.var_type = Some(var_type.clone());
-                        }
+                    if let Some(var_type) = read_pairings.get(&term.ident) {
+                        term.var_type = Some(*var_type);
                     }
                 }
             }

--- a/src/stub/parser.rs
+++ b/src/stub/parser.rs
@@ -45,6 +45,27 @@ impl<'a> Parser<'a> {
             };
         }
 
+        let mut read_pairings = Vec::new();
+        for read_cmd in &stub.commands {
+            if let Cmd::Read(var_cmds) = read_cmd {
+                for var_cmd in var_cmds {
+                    read_pairings.push((var_cmd.ident.clone(), var_cmd.var_type.clone()));
+                }
+            }
+        }        
+
+        for cmd in &mut stub.commands {
+            if let Cmd::WriteJoin { join_terms, output_comment: _ } = cmd {
+                for term in join_terms.iter_mut() {
+                    for (ident, var_type) in &read_pairings {
+                        if term.ident == *ident {
+                            term.var_type = Some(var_type.clone());
+                        }
+                    }
+                }
+            }
+        }
+        
         stub
     }
 

--- a/src/stub/parser/parser_tests.rs
+++ b/src/stub/parser/parser_tests.rs
@@ -62,8 +62,8 @@ fn parse_write_returns_write_joins() {
     let Cmd::WriteJoin { join_terms, .. } = parser.parse_write() else { panic!() };
 
     let [
-        JoinTerm { name: first_term,  .. }, 
-        JoinTerm { name: second_term, .. }
+        JoinTerm { ident: first_term,  .. }, 
+        JoinTerm { ident: second_term, .. }
     ] = join_terms.as_slice() else { panic!() };
 
     assert_eq!(first_term, "hello");

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -9,8 +9,8 @@ const ALPHABET: [char; 18] = [
     'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-pub fn render_stub(config: StubConfig, stub: Stub, debug_mode: bool) -> Result<String> {
-    let renderer = Renderer::new(config, stub, debug_mode)?;
+pub fn render_stub(config: StubConfig, stub: Stub) -> Result<String> {
+    let renderer = Renderer::new(config, stub)?;
     Ok(renderer.render())
 }
 
@@ -18,22 +18,18 @@ struct Renderer {
     tera: Tera,
     lang: Language,
     stub: Stub,
-    debug_mode: bool,
 }
 
 impl Renderer {
-    fn new(config: StubConfig, stub: Stub, debug_mode: bool) -> Result<Renderer> {
+    fn new(config: StubConfig, stub: Stub) -> Result<Renderer> {
         Ok(Self {
             lang: config.language,
             tera: config.tera,
             stub,
-            debug_mode,
         })
     }
 
     fn tera_render(&self, template_name: &str, context: &mut Context) -> String {
-        context.insert("debug_mode", &self.debug_mode);
-
         // Since these are (generally) shared across languages, it makes sense to
         // store it in the "global" context instead of accepting it as parameters.
         let format_symbols = json!({

--- a/src/stub/renderer.rs
+++ b/src/stub/renderer.rs
@@ -101,13 +101,14 @@ impl Renderer {
             .cloned()
             .map(|mut term| {
                 if term.is_variable {
-                    term.name = self.lang.variable_name_options.transform_variable_name(&term.name);
+                    term.ident = self.lang.variable_name_options.transform_variable_name(&term.ident);
                 }
                 term
             })
             .collect();
 
         context.insert("terms", &terms);
+        context.insert("type_tokens", &self.lang.type_tokens);
         context.insert("output_comments", output_comments);
 
         self.tera_render("write_join", &mut context)

--- a/src/stub/stub_config.rs
+++ b/src/stub/stub_config.rs
@@ -49,6 +49,9 @@ impl StubConfig {
     }
 
     pub fn read_from_embedded(lang_name: &str) -> Result<Self> {
+        // If you just created a new template for a language and you get:
+        // Error: No stub generator found for 'language'
+        // you may need to recompile the binaries to update: `cargo build`
         let embedded_config_dir = HARDCODED_TEMPLATE_DIR
             .get_dir(lang_name)
             .context(format!("No stub generator found for '{lang_name}'"))?;

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -502,16 +502,18 @@ loopline anInt x:int
 loopline anInt x:int f:float
 write result
 
-write join(anInt, aFloat, "literal", boolean)
+OUTPUT
+An output comment
+
+write join(anInt, aFloat, Long, boolean)
+
+write join(aWord, "literal", STRING)
 
 STATEMENT
 This is the statement
 
 INPUT
 anInt: An input comment over anInt
-
-OUTPUT
-An output comment
 "##;
     let expected = r##"# This is the statement
 
@@ -542,8 +544,8 @@ for i in range(an_int):
     f = float(inputs[2*i+1])
 # An output comment
 print("result")
-# An output comment
-print(str(an_int) + " " + str(a_float) + " literal " + str(boolean))
+print(str(an_int) + " " + str(a_float) + " " + str(long) + " " + str(boolean))
+print(a_word + " literal " + string)
 "##;
 
     test_stub_builder(generator, expected);

--- a/tests/render_py_tests.rs
+++ b/tests/render_py_tests.rs
@@ -498,6 +498,7 @@ read STRING:string(256)
 read anInt2:int aFloat2:float Long2:long aWord2:word(1) boolean2:bool
 loop anInt read x:int
 loop anInt read x:int f:float
+loop anInt loop anInt read x:int y:int
 loopline anInt x:int
 loopline anInt x:int f:float
 write result
@@ -536,6 +537,9 @@ for i in range(an_int):
     inputs = input().split()
     x = int(inputs[0])
     f = float(inputs[1])
+for i in range(an_int):
+    for j in range(an_int):
+        x, y = [int(k) for k in input().split()]
 for i in input().split():
     x = int(i)
 inputs = input().split()


### PR DESCRIPTION
We need types for writing `WriteJoin` commands in C.

I quickly hacked something in `parser.rs` and tested it. Picture below.

The code itself for adding the types is not ideal and I would like to have your opinion before proceeding. 

![image](https://github.com/ellnix/clash/assets/80173028/b639025a-d3c2-4c79-b37e-acbd63e24c61)

Also:
- (FIXED) `var` should be `term` in `write_join.c.jinja`
- Changed `name` to `ident` in JoinTerm for consistency
- Added `var_type` to JoinTerm (now is_variable became useless since the info is already in the Option var_type, but may be worth keeping for readability)

Edit:
For the moment it can be tested with this handmade clash (but ideally this should be standard and accessible through `gen --debug` or sth):
```
cargo run fetch 90435e82d1d5e3fe5f9d3dd813770f0d5a7d2
cargo run next 90435e82d1d5e3fe5f9d3dd813770f0d5a7d2
cargo run gen c
```